### PR TITLE
release: 메인 브랜치 배포 (멀티 아키텍처 대응) 

### DIFF
--- a/.github/workflows/push-cd.yml
+++ b/.github/workflows/push-cd.yml
@@ -50,20 +50,32 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build -x test # 테스트 제외하고 빌드 실행
 
-      # 6단계 - Docker 이미지 빌드
-      - name: Build Docker image
-        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/myapp:latest . # 현재 디렉토리에서 Dockerfile을 사용하여 이미지 빌드
+      # 6단계 - 멀티 플랫폼 빌드를 위한 QEMU 설정
+      # QEMU는 다양한 아키텍처에서 Docker 이미지를 빌드할 수 있도록 도와줌
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      # 7단계 - Docker Hub에 로그인 & 이미지 푸시
-      - name: Log in to Docker Hub
-        # Docker Hub에 로그인
-        # --password-stdin 옵션은 입력 스트림으로 비밀번호를 넘겨주는 방식 (보안에 유리)
-        # 빌드한 이미지를 Docker Hub에 푸시
-        run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-          docker push ${{ secrets.DOCKER_USERNAME }}/myapp:latest
+      # 7단계 - Docker Buildx 설정 (멀티 플랫폼 빌드 지원)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3 # Docker Buildx 액션 사용
 
-      # 8단계 - Crumb 발급 (Jenkins CSRF 보호)
+      # 8단계 - Docker Hub 로그인
+      - name: Login to Docker hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # 9단계 - ARM64용 Docker 이미지 빌드 및 푸시
+      - name: Build and push ARM64 Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/myapp:latest
+
+      # 10단계 - Crumb 발급 (Jenkins CSRF 보호)
       - name: Get Jenkins Crumb
         id: crumb
         # Jenkins CSRF 보호를 위한 Crumb 발급
@@ -78,7 +90,7 @@ jobs:
           FINAL_CRUMB="$CRUMB_FIELD:$CRUMB_VALUE"
           echo "FINAL_CRUMB=$FINAL_CRUMB" >> $GITHUB_ENV
 
-      # 9단계 - Jenkins Webhook 호출 (배포 트리거)
+      # 11단계 - Jenkins Webhook 호출 (배포 트리거)
       - name: Trigger Jenkins deployment
         # Jenkins에 배포 트리거 요청
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # 베이스 이미지 설정: Java 17 JRE만 포함된 아주 가벼운 Linux 이미지 (Alpine 기반)
 # 이 이미지는 Spring Boot 실행에 필요한 최소한의 환경만 포함하고 있음
-FROM arm64v8/eclipse-temurin:17-jre
+FROM eclipse-temurin:17-jre
 
 # 컨테이너 안에서 작업할 디렉토리 설정 (기본 디렉토리)
 WORKDIR /app


### PR DESCRIPTION
```
[GitHub]
   └─ main 브랜치 push
       ↓
[GitHub Actions]
   ├── Gradle 빌드 (JAR 생성)
   ├── docker buildx (ARM64 이미지 빌드)
   └── docker push → DockerHub
       ↓
[Jenkins @ Raspberry Pi]
   └── Webhook으로 트리거
       └── docker pull + run

```

현재는 GitHub Actions에서 ARM64용 Docker 이미지를 직접 빌드하여 DockerHub에 푸시하고,
라즈베리파이에 설치된 Jenkins가 이를 받아 실행하는 구조입니다.

향후에는 빌드 전용 서버를 별도로 구성하여, Jenkins가 git pull부터 Docker 빌드/푸시까지 전담하고,
라즈베리파이는 단순히 배포만 담당하도록 구조를 개선할 예정입니다.